### PR TITLE
Remove deno from typescript pipeline

### DIFF
--- a/typescript-package/package.json
+++ b/typescript-package/package.json
@@ -12,14 +12,12 @@
     "pipeline": [
       ["@pika/plugin-ts-standard-pkg"],
       ["@pika/plugin-build-node"],
-      ["@pika/plugin-build-web"],
-      ["@pika/plugin-build-deno"]
+      ["@pika/plugin-build-web"]
     ]
   },
   "dependencies": {},
   "devDependencies": {
     "@pika/plugin-build-node": "^0.3.4",
-    "@pika/plugin-build-deno": "^0.3.4",
     "@pika/plugin-build-web": "^0.3.4",
     "@pika/plugin-ts-standard-pkg": "^0.3.4",
     "typescript": "^3.4.5"

--- a/typescript-package/pkg/dist-web/index.js
+++ b/typescript-package/pkg/dist-web/index.js
@@ -1,9 +1,53 @@
-const greetOutLoudAsync = async name => {
-  console.log(`Hello, ${name} (async)`);
-};
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+  try {
+    var info = gen[key](arg);
+    var value = info.value;
+  } catch (error) {
+    reject(error);
+    return;
+  }
+
+  if (info.done) {
+    resolve(value);
+  } else {
+    Promise.resolve(value).then(_next, _throw);
+  }
+}
+
+function _asyncToGenerator(fn) {
+  return function () {
+    var self = this,
+        args = arguments;
+    return new Promise(function (resolve, reject) {
+      var gen = fn.apply(self, args);
+
+      function _next(value) {
+        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
+      }
+
+      function _throw(err) {
+        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+      }
+
+      _next(undefined);
+    });
+  };
+}
+
+const greetOutLoudAsync =
+/*#__PURE__*/
+function () {
+  var _ref = _asyncToGenerator(function* (name) {
+    console.log("Hello, ".concat(name, " (async)"));
+  });
+
+  return function greetOutLoudAsync(_x) {
+    return _ref.apply(this, arguments);
+  };
+}();
 
 const greetOutLoud = name => {
-  console.log(`Hello, ${name}`);
+  console.log("Hello, ".concat(name));
 };
 
 export { greetOutLoud, greetOutLoudAsync };

--- a/typescript-package/pkg/package.json
+++ b/typescript-package/pkg/package.json
@@ -3,24 +3,25 @@
   "description": "A simple example Pika package written in TypeScript",
   "version": "1.0.0",
   "license": "MIT",
-  "source": "dist-src/index.js",
-  "types": "dist-types/index.js",
-  "main": "dist-node/index.js",
-  "module": "dist-web/index.js",
-  "deno": "dist-deno/index.ts",
-  "pika": true,
-  "sideEffects": false,
   "files": [
     "dist-*/",
-    "assets/",
     "bin/"
   ],
+  "source": "dist-src/index.js",
+  "types": "dist-types/index.d.ts",
+  "main": "dist-node/index.js",
+  "module": "dist-web/index.js",
+  "pika": true,
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/@pikapkg/examples.git"
+  },
   "dependencies": {},
   "devDependencies": {
     "@pika/plugin-build-node": "^0.3.4",
-    "@pika/plugin-build-deno": "^0.3.4",
     "@pika/plugin-build-web": "^0.3.4",
     "@pika/plugin-ts-standard-pkg": "^0.3.4",
-    "typescript": "^3.2.2"
+    "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
This PR removes the deno step from the typescript exampel pipeline as mentioned in https://github.com/pikapkg/pack/issues/49#issuecomment-486747637 

Secondly, it updates the /pkg folder after running `pack build` 